### PR TITLE
Fix: Correct PowerShell syntax in GitHub Actions workflow

### DIFF
--- a/.github/workflows/update_servers.yml
+++ b/.github/workflows/update_servers.yml
@@ -43,10 +43,10 @@ jobs:
           git add good_servers.yml
           # Проверяем, есть ли изменения для коммита
           # (git diff --staged --quiet) вернет 0, если нет изменений, и 1, если есть
-          if ! git diff --staged --quiet; then
+          if (!(git diff --staged --quiet)) {
             git commit -m "Automated update: good_servers.yml"
             git push
-          else
+          } else {
             echo "No changes to commit for good_servers.yml."
-          fi
+          }
         # Эта часть гарантирует, что коммит будет сделан только если good_servers.yml действительно изменился.


### PR DESCRIPTION
The `if` statement in the "Commit and push if changes" step had incorrect syntax for PowerShell. I've corrected the syntax by:
- Enclosing the condition in parentheses.
- Placing the `!` (NOT) operator inside the parentheses.
- Changing `then` to `{` and `fi` to `}` to match PowerShell block syntax.

This resolves the ParserError that was occurring during workflow execution.